### PR TITLE
Adds Fisher and AgencyUser as subclasses of User

### DIFF
--- a/app/models/agency_user.rb
+++ b/app/models/agency_user.rb
@@ -1,0 +1,2 @@
+class AgencyUser < User
+end

--- a/app/models/fisher.rb
+++ b/app/models/fisher.rb
@@ -1,4 +1,7 @@
-class Fisher < ApplicationRecord
+class Fisher < User
+  validates :full_name, presence: true
+  validates :permit_number, presence: true
+
   has_many :devices
   has_many :device_uploads, inverse_of: :fisher
 end

--- a/db/migrate/20201231202745_drop_fishers_table.rb
+++ b/db/migrate/20201231202745_drop_fishers_table.rb
@@ -1,0 +1,9 @@
+class DropFishersTable < ActiveRecord::Migration[6.0]
+  def up
+    drop_table :fishers
+  end
+
+  def down
+    create_table :fishers
+  end
+end

--- a/db/migrate/20210102183244_users_sti_fields.rb
+++ b/db/migrate/20210102183244_users_sti_fields.rb
@@ -1,0 +1,10 @@
+class UsersStiFields < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users,  :type, :string, null: false, default: "User"
+    add_column :users, :status, :string, default: 0, null: false
+
+    add_column :users, :permit_number, :string
+    add_column :users, :address, :string, limit: 1024
+    add_column :users, :phone_number, :string, limit: 128
+  end
+end

--- a/db/migrate/20210102183244_users_sti_fields.rb
+++ b/db/migrate/20210102183244_users_sti_fields.rb
@@ -6,5 +6,8 @@ class UsersStiFields < ActiveRecord::Migration[6.0]
     add_column :users, :permit_number, :string
     add_column :users, :address, :string, limit: 1024
     add_column :users, :phone_number, :string, limit: 128
+
+    remove_column :users, :role, :string
+    remove_column :users, :permit, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_022344) do
+ActiveRecord::Schema.define(version: 2021_01_02_183244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,14 +61,6 @@ ActiveRecord::Schema.define(version: 2020_11_18_022344) do
     t.index ["md5_hash"], name: "index_devices_on_md5_hash", unique: true
   end
 
-  create_table "fishers", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
-    t.string "license_number"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -91,6 +83,11 @@ ActiveRecord::Schema.define(version: 2020_11_18_022344) do
     t.string "role", default: "fisher"
     t.string "permit"
     t.string "full_name"
+    t.string "type", default: "User", null: false
+    t.string "status", default: "0", null: false
+    t.string "permit_number"
+    t.string "address", limit: 1024
+    t.string "phone_number", limit: 128
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["permit"], name: "index_users_on_permit", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -80,8 +80,6 @@ ActiveRecord::Schema.define(version: 2021_01_02_183244) do
     t.datetime "locked_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "role", default: "fisher"
-    t.string "permit"
     t.string "full_name"
     t.string "type", default: "User", null: false
     t.string "status", default: "0", null: false
@@ -90,9 +88,7 @@ ActiveRecord::Schema.define(version: 2021_01_02_183244) do
     t.string "phone_number", limit: 128
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["permit"], name: "index_users_on_permit", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["role"], name: "index_users_on_role"
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,13 @@ if Device.count > 0
   puts "randomizing ownership of device records..."
 
   Device.all.in_groups_of(5) do |devices|
-    rando_fisher = Fisher.create(name: Faker::Name.name, license_number: SecureRandom.hex(10), email: Faker::Internet.email)
+    rando_fisher = Fisher.create \
+      full_name: Faker::Name.name,
+      permit_number: SecureRandom.hex(10),
+      email: Faker::Internet.email,
+      password: "password",
+      password_confirmation: "password"
+
     devices.each do |d|
       next if d.blank?
       d.update_attributes(fisher: rando_fisher)

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,7 +1,10 @@
-example_id                             | status  | run_time        |
--------------------------------------- | ------- | --------------- |
-./spec/models/agency_user_spec.rb[1:1] | pending | 0.00001 seconds |
-./spec/models/fisher_spec.rb[1:1:1]    | passed  | 0.00665 seconds |
-./spec/models/user_spec.rb[1:1:1]      | passed  | 0.40814 seconds |
-./spec/system/dashboards_spec.rb[1:1]  | passed  | 0.34531 seconds |
-./spec/system/dashboards_spec.rb[1:2]  | passed  | 0.06427 seconds |
+example_id                                 | status  | run_time        |
+------------------------------------------ | ------- | --------------- |
+./spec/models/agency_user_spec.rb[1:1]     | pending | 0.00001 seconds |
+./spec/models/fisher_spec.rb[1:1:1]        | passed  | 0.00561 seconds |
+./spec/models/user_spec.rb[1:1:1]          | passed  | 0.00465 seconds |
+./spec/system/dashboards_spec.rb[1:1]      | passed  | 0.66096 seconds |
+./spec/system/dashboards_spec.rb[1:2]      | passed  | 0.09161 seconds |
+./spec/system/location_search_spec.rb[1:1] | passed  | 0.05254 seconds |
+./spec/system/location_search_spec.rb[1:2] | passed  | 0.14414 seconds |
+./spec/system/location_search_spec.rb[1:3] | passed  | 0.0949 seconds  |

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,4 +1,7 @@
-example_id                            | status | run_time        |
-------------------------------------- | ------ | --------------- |
-./spec/system/dashboards_spec.rb[1:1] | passed | 0.59105 seconds |
-./spec/system/dashboards_spec.rb[1:2] | passed | 0.09095 seconds |
+example_id                             | status  | run_time        |
+-------------------------------------- | ------- | --------------- |
+./spec/models/agency_user_spec.rb[1:1] | pending | 0.00001 seconds |
+./spec/models/fisher_spec.rb[1:1:1]    | passed  | 0.00665 seconds |
+./spec/models/user_spec.rb[1:1:1]      | passed  | 0.40814 seconds |
+./spec/system/dashboards_spec.rb[1:1]  | passed  | 0.34531 seconds |
+./spec/system/dashboards_spec.rb[1:2]  | passed  | 0.06427 seconds |

--- a/spec/factories/fishers.rb
+++ b/spec/factories/fishers.rb
@@ -1,8 +1,0 @@
-FactoryBot.define do
-  factory :fisher do
-    name { Faker::Name.name }
-    sequence(:email) { |n| "test-email#{n}@example.org" }
-    license_number { SecureRandom.hex(10) }
-  end
-
-end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,4 +4,12 @@ FactoryBot.define do
     password { "password" }
     password_confirmation { "password" }
   end
+
+  factory :fisher, parent: :user, class: 'Fisher' do
+    full_name { Faker::Name.name }
+    permit_number { Faker::Number.number(digits: (8..10).to_a.sample) }
+  end
+
+  factory :agency_user, parent: :user, class: 'AgencyUser' do
+  end
 end

--- a/spec/models/agency_user_spec.rb
+++ b/spec/models/agency_user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AgencyUser, type: :model do
+  pending "let's add some tests here soon"
+end

--- a/spec/models/fisher_spec.rb
+++ b/spec/models/fisher_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Fisher, type: :model do
+  context "validations" do
+    it "requires a name and permit number" do
+      fisher = FactoryBot.build(:fisher, full_name: nil, permit_number: nil)
+      expect(fisher).to_not be_valid
+      expect(fisher.errors.keys).to eql(%i(full_name permit_number))
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  context "validations" do
+    it "requires an email address, password, and password_confirmation" do
+      fisher = FactoryBot.build(:fisher, email: nil, password: nil, password_confirmation: nil)
+      expect(fisher).to_not be_valid
+      expect(fisher.errors.keys).to eql(%i(email password))
+    end
+  end
+end


### PR DESCRIPTION
* we'll use a single table for all authenticable users
* drops the `fishers` table
* adds _very_ basic tests for fisher

Verified that

```
rake db:drop
heroku pg:pull DATABASE_URL ropeless_web_development
rake db:migrate
rake db:seed
```

is 👍🏻 