### PR TITLE
Adds missing Fisher address fields to the sign up form

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -42,7 +42,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:access_needed, :full_name, :permit_number, :address, :phone_number])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:access_needed, :full_name, :permit_number, :address, :city, :state, :zip_code, :phone_number])
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -44,6 +44,21 @@
         <%= f.text_field :address, class: "form-control" %>
       </div>
 
+      <div class="form-group<%= resource.errors[:city].any? ? " errored" : "" %>" data-show-if="Fisher">
+        <%= f.label :city %><br />
+        <%= f.text_field :city, class: "form-control" %>
+      </div>
+
+      <div class="form-group<%= resource.errors[:state].any? ? " errored" : "" %>" data-show-if="Fisher">
+        <%= f.label :state, "State / Province" %><br />
+        <%= f.text_field :state, class: "form-control" %>
+      </div>
+
+      <div class="form-group<%= resource.errors[:zip_code].any? ? " errored" : "" %>" data-show-if="Fisher">
+        <%= f.label :zip_code, "ZIP code" %><br />
+        <%= f.text_field :zip_code, class: "form-control" %>
+      </div>
+
       <div class="form-group<%= resource.errors[:phone_number].any? ? " errored" : "" %>" data-show-if="Fisher">
         <%= f.label :phone_number %><br />
         <%= f.phone_field :phone_number, class: "form-control" %>

--- a/db/migrate/20210114005837_add_address_field_to_users.rb
+++ b/db/migrate/20210114005837_add_address_field_to_users.rb
@@ -1,0 +1,7 @@
+class AddAddressFieldToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :city, :string, limit: 128
+    add_column :users, :state, :string, limit: 128
+    add_column :users, :zip_code, :string, limit: 5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_13_012510) do
+ActiveRecord::Schema.define(version: 2021_01_14_005837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,9 @@ ActiveRecord::Schema.define(version: 2021_01_13_012510) do
     t.string "permit_number"
     t.string "address", limit: 1024
     t.string "phone_number", limit: 128
+    t.string "city", limit: 128
+    t.string "state", limit: 128
+    t.string "zip_code", limit: 5
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
Closes #30, adds city, state, and ZIP code to the form. Values need to be manually entered in for now. KISS.