### PR TITLE
Admin access request management

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -13,9 +13,15 @@ class AccessRequestsController < ApplicationController
     user = User.find(params[:id])
 
     if user.update_attributes(update_params)
-      flash[:success] = "Changes saved"
+      if user.active?
+        flash[:success] = "Access request approved."
+        AccessRequestsMailer.approved_email(user).deliver_now
+      else
+        flash[:success] = "Access request rejected."
+        AccessRequestsMailer.rejected_email(user).deliver_now
+      end
     else
-      flash[:error] = "Failed to save changes"
+      flash[:error] = "Unknown option passed, please approve or reject the access request."
     end
 
     redirect_to access_requests_url

--- a/app/mailers/access_requests_mailer.rb
+++ b/app/mailers/access_requests_mailer.rb
@@ -1,0 +1,13 @@
+class AccessRequestsMailer < ApplicationMailer
+  default from: 'noreply@smelts.org'
+
+  def approved_email(user)
+    @user = user
+    mail(to: @user.email, subject: "Welcome to the Smelts data collection system")
+  end
+
+  def rejected_email(user)
+    @user = user
+    mail(to: @user.email, subject: "Thanks for requesting access to Smelts")
+  end
+end

--- a/app/views/access_requests/index.html.erb
+++ b/app/views/access_requests/index.html.erb
@@ -7,73 +7,80 @@
 <div class="container-lg mt-4 d-flex">
   <div class="col-12">
     <div class="Box">
-      <div class="Box-header">
-        <h3 class="Box-title">
-          The following users are requesting access
-        </h3>
-      </div>
-      <div class="Box-body">
+      <% if @access_requests.none? %>
+        <div class="blankslate">
+          <h3 class="mb-1">There are no outstanding access requests.</h3>
+          <p>Enjoy your day!</p>
+        </div>
+      <% else %>
+        <div class="Box-header">
+          <h3 class="Box-title">
+            The following users are requesting access
+          </h3>
+        </div>
+        <div class="Box-body">
         <table class="width-full">
           <thead>
-            <tr class="border-bottom">
-              <th>Full Name</th>
-              <th>Access Needed</th>
-              <th>E-mail address</th>
-              <th>Permit Number</th>
-              <th></th>
-            </tr>
+          <tr class="border-bottom">
+            <th>Full Name</th>
+            <th>Access Needed</th>
+            <th>E-mail address</th>
+            <th>Permit Number</th>
+            <th></th>
+          </tr>
           </thead>
           <tbody>
-            <% @access_requests.each do |user| %>
-              <tr class="border-bottom">
-                <td class="p-2 css-truncate css-truncate-overflow" style="width: 200px;" title="<%= user.full_name %>">
-                  <strong><%= user.full_name %></strong>
-                </td>
-                <td class="p-2">
-                  <%= user.class.name.titleize %>
-                </td>
-                <td class="p-2">
-                  <%= user.email %>
-                </td>
-                <td class="p-2">
-                  <% if user.is_a?(Fisher) %>
-                    <%= user.permit_number %>
-                  <% else %>
-                    N/A
+          <% @access_requests.each do |user| %>
+            <tr class="border-bottom">
+              <td class="p-2 css-truncate css-truncate-overflow" style="width: 200px;" title="<%= user.full_name %>">
+                <strong><%= user.full_name %></strong>
+              </td>
+              <td class="p-2">
+                <%= user.class.name.titleize %>
+              </td>
+              <td class="p-2">
+                <%= user.email %>
+              </td>
+              <td class="p-2">
+                <% if user.is_a?(Fisher) %>
+                  <%= user.permit_number %>
+                <% else %>
+                  N/A
+                <% end %>
+              </td>
+              <td class="p-2">
+                <div class="mr-2">
+                  <%= form_for user, url: access_request_path(user), html: {class: "d-inline-block"} do |f| %>
+                    <%= hidden_field_tag("user[status]", :active) %>
+                    <%= f.button class: "btn btn-sm btn-primary" do %>
+                      <%= octicon "zap" %>
+                      Approve
+                    <% end %>
                   <% end %>
-                </td>
-                <td class="p-2">
-                  <div class="mr-2">
-                    <%= form_for user, url: access_request_path(user), html: {class: "d-inline-block"} do |f| %>
-                      <%= hidden_field_tag("user[status]", :active) %>
-                      <%= f.button class: "btn btn-sm btn-primary" do %>
-                        <%= octicon "zap" %>
-                        Approve
-                      <% end %>
+                  <%= form_for user, url: access_request_path(user), html: {class: "d-inline-block"} do |f| %>
+                    <%= hidden_field_tag("user[status]", :rejected) %>
+                    <%= f.button class: "btn btn-sm btn-danger" do %>
+                      <%= octicon "trashcan" %>
+                      Reject
                     <% end %>
-                    <%= form_for user, url: access_request_path(user), html: {class: "d-inline-block"} do |f| %>
-                      <%= hidden_field_tag("user[status]", :rejected) %>
-                      <%= f.button class: "btn btn-sm btn-danger" do %>
-                        <%= octicon "trashcan" %>
-                        Reject
-                      <% end %>
-                    <% end %>
-                  </div>
-                </td>
-              </tr>
-            <% end %>
+                  <% end %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
           </tbody>
           <% if @access_requests.total_pages > 1 %>
             <tfoot>
-              <tr>
-                <td colspan="5">
-                  <%= will_paginate @access_requests, previous_label: "Previous", next_label: "Next" %>
-                </td>
-              </tr>
+            <tr>
+              <td colspan="5">
+                <%= will_paginate @access_requests, previous_label: "Previous", next_label: "Next" %>
+              </td>
+            </tr>
             </tfoot>
           <% end %>
         </table>
       </div>
+      <% end  %>
     </div>
   </div>
 </div>

--- a/app/views/access_requests_mailer/approved_email.html.erb
+++ b/app/views/access_requests_mailer/approved_email.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+</head>
+<body>
+<h1>Hi, <%= @user.full_name %></h1>
+<p>
+  Your request for access to the Smelts ropeless web app has been approved. You can now use the email and password you provided to sign in to <a href="https://ropeless-web.herokuapp.com">the website</a>.
+</p>
+<p>
+  Have a great day,
+</p>
+<p>The Smelts.org team</p>
+</body>
+</html>

--- a/app/views/access_requests_mailer/approved_email.text.erb
+++ b/app/views/access_requests_mailer/approved_email.text.erb
@@ -1,0 +1,7 @@
+Hi, <%= @user.full_name %>
+
+Your request for access to the Smelts ropeless web app has been approved. You can now use the email and password you provided to sign in to https://ropeless-web.herokuapp.com.
+
+Have a great day,
+
+The Smelts.org team

--- a/app/views/access_requests_mailer/rejected_email.html.erb
+++ b/app/views/access_requests_mailer/rejected_email.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+</head>
+<body>
+<h1>Hi, <%= @user.full_name %></h1>
+<p>
+  Your request for access to the Smelts ropeless web app has been rejected. If you feel this is an error please reach out to us at <a href="mailto:info@smelts.org">info@smelts.org</a>.
+</p>
+<p>
+  Have a great day,
+</p>
+<p>The Smelts.org team</p>
+</body>
+</html>

--- a/app/views/access_requests_mailer/rejected_email.text.erb
+++ b/app/views/access_requests_mailer/rejected_email.text.erb
@@ -1,0 +1,7 @@
+Hi, <%= @user.full_name %>
+
+Your request for access to the Smelts ropeless web app has been rejected. If you feel this is an error please reach out to us at info@smelts.org.
+
+Have a great day,
+
+The Smelts.org team

--- a/app/views/thanks/show.html.erb
+++ b/app/views/thanks/show.html.erb
@@ -1,2 +1,8 @@
-<h1>Thanks!</h1>
-<p>Thank you for requesting access. We will be in touch with you shortly via email if we have any further questions.</p>
+<div class="container-lg mt-4 d-flex">
+  <div class="col-12">
+    <div class="Box p-4">
+      <h1>Thanks!</h1>
+      <p>Thank you for requesting access. We will be in touch with you shortly via email if we have any further questions. You may safely close this window.</p>
+    </div>
+  </div>
+</div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,6 +62,16 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  ActionMailer::Base.smtp_settings = {
+    :port           => ENV['MAILGUN_SMTP_PORT'],
+    :address        => ENV['MAILGUN_SMTP_SERVER'],
+    :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
+    :password       => ENV['MAILGUN_SMTP_PASSWORD'],
+    :domain         => 'ropeless-web.herokuapp.com',
+    :authentication => :plain,
+  }
+  ActionMailer::Base.delivery_method = :smtp
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/spec/mailers/access_requests_mailer_spec.rb
+++ b/spec/mailers/access_requests_mailer_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe AccessRequestsMailer, type: :mailer do
+  context "when approved for access" do
+    it "renders the headers" do
+      user = FactoryBot.create(:fisher, :needs_confirmation)
+      mail = AccessRequestsMailer.approved_email(user)
+      expect(mail.subject).to eq("Welcome to the Smelts data collection system")
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq(["noreply@smelts.org"])
+    end
+
+    it "renders the body" do
+      user = FactoryBot.create(:fisher, :needs_confirmation)
+      mail = AccessRequestsMailer.approved_email(user)
+      expect(mail.body.encoded).to match("Your request for access to the Smelts ropeless web app has been approved")
+    end
+  end
+
+  context "when access is rejected" do
+    it "renders the headers" do
+      user = FactoryBot.create(:fisher, :needs_confirmation)
+      mail = AccessRequestsMailer.rejected_email(user)
+      expect(mail.subject).to eq("Thanks for requesting access to Smelts")
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq(["noreply@smelts.org"])
+    end
+
+    it "renders the body" do
+      user = FactoryBot.create(:fisher, :needs_confirmation)
+      mail = AccessRequestsMailer.rejected_email(user)
+      expect(mail.body.encoded).to match("Your request for access to the Smelts ropeless web app has been rejected")
+    end
+  end
+end

--- a/spec/mailers/previews/access_requests_mailer_preview.rb
+++ b/spec/mailers/previews/access_requests_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/access_requests_mailer
+class AccessRequestsMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/system/access_requests_spec.rb
+++ b/spec/system/access_requests_spec.rb
@@ -71,4 +71,22 @@ RSpec.describe "Access Requests", type: :system do
     expect(fisher.active_for_authentication?).to be_falsey
     expect(fisher.rejected?).to be_truthy
   end
+
+  it "sends an email when an access request is approved" do
+    FactoryBot.create(:fisher, :needs_confirmation)
+    login_as FactoryBot.create(:user, :active)
+
+    visit "/access_requests"
+
+    expect { find_button("Approve").click }.to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
+
+  it "sends an email when an access request is rejected" do
+    FactoryBot.create(:fisher, :needs_confirmation)
+    login_as FactoryBot.create(:user, :active)
+
+    visit "/access_requests"
+
+    expect { find_button("Reject").click }.to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
 end


### PR DESCRIPTION
This adds the ability for admin users to manage access requests for fisher and agency users who've requested access.

The page includes an approve/reject button that, when clicked, will send the users an email informing them of the decision.

This does NOT include an email going to admin users letting someone know that an access request is waiting.

<img width="1199" alt="Screen Shot 2021-01-25 at 08 54 11" src="https://user-images.githubusercontent.com/2804/105714898-ed358d00-5eea-11eb-8837-13f69ff4ffd8.png">
