### PR TITLE
Adds support for automatically running database migrations on releases

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: rake db:migrate
 web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
Enough said. I haven't confirmed if this works  yet, so the next migration we should pay close attention @AlbertGrimley 