### PR TITLE
Admin MVP of user management

### DIFF
--- a/app/controllers/admin/access_requests_controller.rb
+++ b/app/controllers/admin/access_requests_controller.rb
@@ -1,4 +1,4 @@
-class AccessRequestsController < ApplicationController
+class Admin::AccessRequestsController < AdminController
 
   before_action :require_admin_user
 
@@ -24,7 +24,7 @@ class AccessRequestsController < ApplicationController
       flash[:error] = "Unknown option passed, please approve or reject the access request."
     end
 
-    redirect_to access_requests_url
+    redirect_to admin_access_requests_url
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,25 @@
+class Admin::UsersController < AdminController
+
+  def index
+    @users = User.paginate(page: params[:page])
+  end
+
+  def update
+    user = User.find(params[:id])
+
+    if user.update(update_params)
+      UsersMailer.deactivated_email(user).deliver_now if user.deactivated?
+      flash[:success] = "Changes saved"
+    else
+      flash[:error] = "Unable to save that change"
+    end
+
+    redirect_to admin_users_url
+  end
+
+  private
+
+  def update_params
+    params.require(:user).permit(:status)
+  end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,9 @@
+class AdminController < ApplicationController
+  before_action :require_admin_user
+
+  private
+
+  def require_admin_user
+    redirect_to root_url and return unless current_user_admin?
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,8 +5,4 @@ class ApplicationController < ActionController::Base
     current_user && current_user.class.name == "User"
   end
   helper_method :current_user_admin?
-
-  def require_admin_user
-    redirect_to root_url and return unless current_user_admin?
-  end
 end

--- a/app/mailers/users_mailer.rb
+++ b/app/mailers/users_mailer.rb
@@ -1,0 +1,8 @@
+class UsersMailer < ApplicationMailer
+  default from: 'noreply@smelts.org'
+
+  def deactivated_email(user)
+    @user = user
+    mail(to: @user.email, subject: "Your account has been deactivated")
+  end
+end

--- a/app/views/access_requests/show.html.erb
+++ b/app/views/access_requests/show.html.erb
@@ -1,2 +1,0 @@
-<h1>AccessRequests#show</h1>
-<p>Find me in app/views/access_requests/show.html.erb</p>

--- a/app/views/admin/access_requests/index.html.erb
+++ b/app/views/admin/access_requests/index.html.erb
@@ -50,14 +50,14 @@
               </td>
               <td class="p-2">
                 <div class="mr-2">
-                  <%= form_for user, url: access_request_path(user), html: {class: "d-inline-block"} do |f| %>
+                  <%= form_for user, url: admin_access_request_path(user), html: {class: "d-inline-block"} do |f| %>
                     <%= hidden_field_tag("user[status]", :active) %>
                     <%= f.button class: "btn btn-sm btn-primary" do %>
                       <%= octicon "zap" %>
                       Approve
                     <% end %>
                   <% end %>
-                  <%= form_for user, url: access_request_path(user), html: {class: "d-inline-block"} do |f| %>
+                  <%= form_for user, url: admin_access_request_path(user), html: {class: "d-inline-block"} do |f| %>
                     <%= hidden_field_tag("user[status]", :rejected) %>
                     <%= f.button class: "btn btn-sm btn-danger" do %>
                       <%= octicon "trashcan" %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,71 @@
+<div class="container-lg mt-4">
+  <div class="col-12">
+    <h2>Users</h2>
+  </div>
+</div>
+
+<div class="container-lg mt-4 d-flex">
+  <div class="col-12">
+    <div class="Box">
+      <div class="Box-body">
+        <table class="width-full">
+          <thead>
+          <tr class="border-bottom">
+            <th>Full Name</th>
+            <th>Access Needed</th>
+            <th>E-mail address</th>
+            <th>Permit Number</th>
+            <th></th>
+          </tr>
+          </thead>
+          <tbody>
+          <% @users.each do |user| %>
+            <tr class="border-bottom">
+              <td class="p-2 css-truncate css-truncate-overflow" style="width: 200px;" title="<%= user.full_name %>">
+                <strong><%= user.full_name %></strong>
+              </td>
+              <td class="p-2">
+                <%= user.class.name.titleize %>
+              </td>
+              <td class="p-2">
+                <%= user.email %>
+              </td>
+              <td class="p-2">
+                <% if user.is_a?(Fisher) %>
+                  <%= user.permit_number %>
+                <% else %>
+                  N/A
+                <% end %>
+              </td>
+              <td class="p-2">
+                <div class="mr-2">
+                  <% if user == current_user %>
+                    <p class="note">Unable to deactivate your own account</p>
+                  <% else %>
+                    <%= form_for user, url: admin_access_request_path(user), html: {class: "d-inline-block"} do |f| %>
+                      <%= hidden_field_tag("user[status]", :deactivated) %>
+                      <%= f.button class: "btn btn-sm btn-danger" do %>
+                        <%= octicon "trashcan" %>
+                        Deactivate
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+          </tbody>
+          <% if @users.total_pages > 1 %>
+            <tfoot>
+            <tr>
+              <td colspan="5">
+                <%= will_paginate @users, previous_label: "Previous", next_label: "Next" %>
+              </td>
+            </tr>
+            </tfoot>
+          <% end %>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
         <% if current_user_admin? %>
           <div class="Header-item">
             <%= octicon("person") %>
-            <%= link_to("Access Requests", access_requests_url, class: "ml-2 Header-link") %>
+            <%= link_to("Access Requests", admin_access_requests_url, class: "ml-2 Header-link") %>
             <% if User.outstanding_access_requests.any? %>
               <span class="Counter ml-2"><%= User.outstanding_access_requests.count %></span>
             <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,10 @@
         <% if current_user_admin? %>
           <div class="Header-item">
             <%= octicon("person") %>
+            <%= link_to("User Management", admin_users_url, class: "ml-2 Header-link") %>
+          </div>
+          <div class="Header-item">
+            <%= octicon("check") %>
             <%= link_to("Access Requests", admin_access_requests_url, class: "ml-2 Header-link") %>
             <% if User.outstanding_access_requests.any? %>
               <span class="Counter ml-2"><%= User.outstanding_access_requests.count %></span>

--- a/app/views/users_mailer/deactivated_email.html.erb
+++ b/app/views/users_mailer/deactivated_email.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+</head>
+<body>
+<h1>Hi, <%= @user.full_name %></h1>
+<p>
+  Your account has been deactivated. If you feel this is an error please reach out to us at <a href="mailto:info@smelts.org">info@smelts.org</a>.
+</p>
+<p>
+  Have a great day,
+</p>
+<p>The Smelts.org team</p>
+</body>
+</html>

--- a/app/views/users_mailer/deactivated_email.text.erb
+++ b/app/views/users_mailer/deactivated_email.text.erb
@@ -1,0 +1,7 @@
+Hi, <%= @user.full_name %>
+
+Your account has been deactivated. If you feel this is an error please reach out to us at info@smelts.org.
+
+Have a great day,
+
+The Smelts.org team

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :access_requests, only: %w(index show update)
+    resources :users, only: %w(index update)
   end
 
   devise_for :users, controllers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,10 @@ Rails.application.routes.draw do
   resources :devices
   resources :device_uploads, controller: "device_upload"
   resources :location_search, controller: "location_search"
-  resources :access_requests, only: %w(index show update)
+
+  namespace :admin do
+    resources :access_requests, only: %w(index show update)
+  end
 
   devise_for :users, controllers: {
     registrations: 'users/registrations',

--- a/spec/mailers/users_mailer_spec.rb
+++ b/spec/mailers/users_mailer_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe UsersMailer, type: :mailer do
+  context "when deactivated" do
+    it "renders the headers" do
+      user = FactoryBot.create(:fisher, :needs_confirmation)
+      mail = UsersMailer.deactivated_email(user)
+      expect(mail.subject).to eq("Your account has been deactivated")
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq(["noreply@smelts.org"])
+    end
+
+    it "renders the body" do
+      user = FactoryBot.create(:fisher, :needs_confirmation)
+      mail = UsersMailer.deactivated_email(user)
+      expect(mail.body.encoded).to match("Your account has been deactivated")
+    end
+  end
+end

--- a/spec/system/access_requests_spec.rb
+++ b/spec/system/access_requests_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Access Requests", type: :system do
   end
 
   it "requires a login" do
-    visit "/access_requests"
+    visit "/admin/access_requests"
 
     expect(page).to have_current_path("/users/sign_in")
   end
@@ -14,7 +14,7 @@ RSpec.describe "Access Requests", type: :system do
   it "required an admin user" do
     login_as FactoryBot.create(:fisher, :active)
 
-    visit "/access_requests"
+    visit "/admin/access_requests"
 
     expect(page).to have_current_path("/")
   end
@@ -23,7 +23,7 @@ RSpec.describe "Access Requests", type: :system do
     login_as FactoryBot.create(:user, :active)
     2.times { FactoryBot.create(:fisher, :needs_confirmation) }
 
-    visit "/access_requests"
+    visit "/admin/access_requests"
 
     expect(page).to have_text("Access Requests 2")
   end
@@ -33,7 +33,7 @@ RSpec.describe "Access Requests", type: :system do
     agency_user = FactoryBot.create(:agency_user, :needs_confirmation)
     login_as FactoryBot.create(:user, :active)
 
-    visit "/access_requests"
+    visit "/admin/access_requests"
 
     expect(page).to have_text(fisher.full_name)
     expect(page).to have_text(fisher.email)
@@ -49,7 +49,7 @@ RSpec.describe "Access Requests", type: :system do
     expect(fisher.active_for_authentication?).to be_falsey
     expect(fisher.needs_confirmation?).to be_truthy
 
-    visit "/access_requests"
+    visit "/admin/access_requests"
 
     find_button("Approve").click
 
@@ -63,7 +63,7 @@ RSpec.describe "Access Requests", type: :system do
     login_as FactoryBot.create(:user, :active)
     expect(fisher.active_for_authentication?).to be_falsey
 
-    visit "/access_requests"
+    visit "/admin/access_requests"
 
     find_button("Reject").click
 
@@ -76,7 +76,7 @@ RSpec.describe "Access Requests", type: :system do
     FactoryBot.create(:fisher, :needs_confirmation)
     login_as FactoryBot.create(:user, :active)
 
-    visit "/access_requests"
+    visit "/admin/access_requests"
 
     expect { find_button("Approve").click }.to change { ActionMailer::Base.deliveries.count }.by(1)
   end
@@ -85,7 +85,7 @@ RSpec.describe "Access Requests", type: :system do
     FactoryBot.create(:fisher, :needs_confirmation)
     login_as FactoryBot.create(:user, :active)
 
-    visit "/access_requests"
+    visit "/admin/access_requests"
 
     expect { find_button("Reject").click }.to change { ActionMailer::Base.deliveries.count }.by(1)
   end

--- a/spec/system/admin/access_requests_spec.rb
+++ b/spec/system/admin/access_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Access Requests", type: :system do
+RSpec.describe "Admin > Access Requests", type: :system do
   before do
     driven_by(:rack_test)
   end

--- a/spec/system/admin/users_requests_spec.rb
+++ b/spec/system/admin/users_requests_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe "Admin > Users", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  it "requires a login" do
+    visit "/admin/users"
+
+    expect(page).to have_current_path("/users/sign_in")
+  end
+
+  it "required an admin user" do
+    login_as FactoryBot.create(:fisher, :active)
+
+    visit "/admin/users"
+
+    expect(page).to have_current_path("/")
+  end
+
+  it "shows information about users" do
+    fisher = FactoryBot.create(:fisher, :active)
+    agency_user = FactoryBot.create(:agency_user, :active)
+    login_as FactoryBot.create(:user, :active)
+
+    visit "/admin/users"
+
+    expect(page).to have_text(fisher.full_name)
+    expect(page).to have_text(fisher.email)
+    expect(page).to have_text(fisher.permit_number)
+    expect(page).to have_text(agency_user.full_name)
+    expect(page).to have_text(agency_user.email)
+  end
+
+  it "lets admin users deactivate user accounts" do
+    fisher = FactoryBot.create(:fisher, :active)
+    login_as FactoryBot.create(:user, :active)
+
+    visit "/admin/users"
+
+
+    find_button("Deactivate").click
+
+    fisher.reload
+    expect(fisher.active_for_authentication?).to be_falsey
+    expect(fisher.deactivated?).to be_truthy
+  end
+
+  it "sends an email when access is removed" do
+    FactoryBot.create(:fisher, :active)
+    login_as FactoryBot.create(:user, :active)
+
+    visit "/admin/users"
+
+    expect { find_button("Deactivate").click }.to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
+end


### PR DESCRIPTION
Part of https://github.com/smelts-tech/ropeless_web/issues/12, adds the ability for admins to manage user account access.

* admins can deactivate user accounts
* deactivations locks users out of the system
* deactivation does not delete any information