### PR TITLE
Correct the URL for the user management form

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -42,7 +42,7 @@
                   <% if user == current_user %>
                     <p class="note">Unable to deactivate your own account</p>
                   <% else %>
-                    <%= form_for user, url: admin_access_request_path(user), html: {class: "d-inline-block"} do |f| %>
+                    <%= form_for user, url: admin_user_path(user), html: {class: "d-inline-block"} do |f| %>
                       <%= hidden_field_tag("user[status]", :deactivated) %>
                       <%= f.button class: "btn btn-sm btn-danger" do %>
                         <%= octicon "trashcan" %>


### PR DESCRIPTION
This was causing the request to go to the wrong controller. I also updated some of the models on production that were missing newly required info (like address, etc.) so the status changes work (to activate/deactivate users, to approve/reject access requests).